### PR TITLE
Used more elaborated code style (by @shaolinfry)

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2050,13 +2050,14 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     }
 
     // BIP148 mandatory segwit signalling.
-    if (pindex->GetMedianTimePast() >= 1501545600 && // Tue 1 Aug 2017 00:00:00 UTC
-        pindex->GetMedianTimePast() <= 1510704000 && // Wed 15 Nov 2017 00:00:00 UTC
-        !IsWitnessEnabled(pindex->pprev, chainparams.GetConsensus()))
+    int64_t nMedianTimePast = pindex->GetMedianTimePast();
+    if ( (nMedianTimePast >= 1506816000) &&   // Sun Oct 1 00:00:00 UTC 2017
+         (nMedianTimePast <= 1510704000) &&   // Sun Nov 15 00:00:00 UTC 2017
+         (!IsWitnessEnabled(pindex->pprev, chainparams.GetConsensus())) )  // Segwit is not active
     {
-        // versionbits topbit and segwit flag must be set.
-        if ((pindex->nVersion & VERSIONBITS_TOP_MASK) != VERSIONBITS_TOP_BITS ||
-            (pindex->nVersion & VersionBitsMask(chainparams.GetConsensus(), Consensus::DEPLOYMENT_SEGWIT)) == 0) {
+        bool fVersionBits = (pindex->nVersion & VERSIONBITS_TOP_MASK) == VERSIONBITS_TOP_BITS; // BIP9 bit set
+        bool fSegbit = (pindex->nVersion & VersionBitsMask(chainparams.GetConsensus(), Consensus::DEPLOYMENT_SEGWIT)) != 0; // segwit bit set
+        if (!(fVersionBits && fSegbit)) {
             return state.DoS(0, error("ConnectBlock(): relayed block must signal for segwit, please upgrade"), REJECT_INVALID, "bad-no-segwit");
         }
     }


### PR DESCRIPTION
Took the code style change proposed in
https://github.com/bitcoin/bips/commit/cc67ae995c4df0b0e1040c34f8f68848954de35a#commitcomment-21492834

but added small tweaks
- no need to calculate median time twice (not that it matters, but why not)
- extra ( )

Imo this is most readable version, at least I can wake up
in middle of night and it is instantly clear from first look
what this BIP148 check does.